### PR TITLE
docs(jssdkv3): add links to jssdk v3

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -191,7 +191,6 @@ function sidebarSdk() {
       text: "JavaScript SDK v2 (legacy)",
       link: "/guide/java-script-api-reference",
     },    
-    { text: "GPS JS SDK (current)", link: "https://github.com/expofp/gps-efp-app" },
     {
       text: "iOS Swift SDK v5 (current)",
       link: "https://expofp.github.io/expofp-sdk-ios/documentation/expofp/",
@@ -222,11 +221,11 @@ function changelogItems() {
       link: "https://expofp.github.io/changelog/efp-app/",
     },
      {
-      text: "iOS Swift SDK v5 Changelog",
+      text: "iOS SDK v5 Changelog",
       link: "https://expofp.github.io/expofp-sdk-ios/documentation/expofp/changelog-history",
     },
      {
-      text: "Android Kotlin SDK v5 Changelog",
+      text: "Android SDK v5 Changelog",
       link: "https://expofp.github.io/expofp-fplan-android/articles/changelog",
     },
   ];

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -183,26 +183,30 @@ function sidebarExamples() {
 
 function sidebarSdk() {
   return [
-     {
-      text: "JavaScript SDK (current)",
+    {
+      text: "JavaScript SDK v3 (current)",
+      link: "https://js-sdk.expofp.com/",
+    },
+    {
+      text: "JavaScript SDK v2 (legacy)",
       link: "/guide/java-script-api-reference",
     },    
-    {
-      text: "Android Java SDK v4 (legacy)",
-      link: "https://expofp.github.io/expofp-mobile-sdk/android-sdk/",
-    },
     { text: "GPS JS SDK (current)", link: "https://github.com/expofp/gps-efp-app" },
+    {
+      text: "iOS Swift SDK v5 (current)",
+      link: "https://expofp.github.io/expofp-sdk-ios/documentation/expofp/",
+    },
     {
       text: "iOS Swift SDK v4 (legacy)",
       link: "https://expofp.github.io/expofp-mobile-sdk/ios-sdk/",
     },
     {
-      text: "iOS Swift SDK v5 (current)",
-      link: `https://expofp.github.io/expofp-sdk-ios/documentation/expofp/`,
+      text: "Android Kotlin SDK v5 (current)",
+      link: "https://expofp.github.io/expofp-fplan-android/",
     },
     {
-      text: "Android Kotlin SDK v5 (current)",
-      link: `https://expofp.github.io/expofp-fplan-android/`,
+      text: "Android Java SDK v4 (legacy)",
+      link: "https://expofp.github.io/expofp-mobile-sdk/android-sdk/",
     },
     {
       text: "ReactNative SDK (current)",


### PR DESCRIPTION
Added links to JS SDK v3

Apply them when vite-main release