### PR TITLE
docs(guide): expand JSON API page with intro + capability list

### DIFF
--- a/docs/guide/json-api.md
+++ b/docs/guide/json-api.md
@@ -1,3 +1,16 @@
 # JSON API
 
- [View ExpoFP.com JSON API reference](https://expofp.docs.apiary.io)
+The ExpoFP JSON API is a REST API that lets you programmatically manage your event floor plans and exhibitor data. Use it to integrate ExpoFP with your existing event management platform, CRM, or registration system — keeping booth assignments, exhibitor profiles, and floor plan data in sync without manual imports.
+
+## What you can do with the API
+
+- **Manage exhibitors** — create, update, and delete exhibitor profiles including company details, logos, descriptions, and contact information.
+- **Assign booths** — add or remove booth assignments for exhibitors, mark booths as reserved or sold.
+- **Manage extras** — assign sponsorship packages, booth extras, and featured listings to exhibitors.
+- **Read floor plan data** — retrieve information about booths, exhibitors, and categories on your floor plan.
+
+Authentication is handled via an API key passed with each request.
+
+**Base URL:** `https://app.expofp.com`
+
+The full interactive reference — with request/response examples for every endpoint — is available at [expofp.docs.apiary.io](https://expofp.docs.apiary.io).

--- a/docs/guide/json-api.md
+++ b/docs/guide/json-api.md
@@ -9,7 +9,7 @@ The ExpoFP JSON API is a REST API that lets you programmatically manage your eve
 - **Manage extras** — assign sponsorship packages, booth extras, and featured listings to exhibitors.
 - **Read floor plan data** — retrieve information about booths, exhibitors, and categories on your floor plan.
 
-Authentication is handled via an API key passed with each request.
+Authentication is handled via an API key passed with each request. Get your key from [your ExpoFP profile page](https://app.expofp.com/profile/).
 
 **Base URL:** `https://app.expofp.com`
 


### PR DESCRIPTION
## Summary

- Replaces the previous one-line JSON API page (just a link to the apiary reference) with the introduction paragraph and capability list supplied by @denilin in Slack.
- The apiary reference is preserved as the closing line of the page (same URL as before), so the page now leads with prose and lands on the reference link.

## Test plan

- [ ] Visual check on `yarn start` / preview build — page renders the bullet list and bolded labels as expected
- [ ] Check that the navigation entry under *Guide* still resolves to this page